### PR TITLE
resolving debug output issues which were ignoring config

### DIFF
--- a/fortenet.gemspec
+++ b/fortenet.gemspec
@@ -10,16 +10,16 @@ Gem::Specification.new do |spec|
   spec.email         = ["iiwo@o2.pl"]
   spec.summary       = %q{Simple wrapper for Forte.net REST API}
   spec.description   = %q{Simple wrapper for Forte.net REST API (work in progress) }
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/ArcadiaPower/fortenet"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'httparty'
+  spec.add_runtime_dependency 'httparty', '~> 0.13'
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", '~> 12.0'
 end

--- a/lib/fortenet.rb
+++ b/lib/fortenet.rb
@@ -10,8 +10,15 @@ module Fortenet
   mattr_accessor :debug
   @@debug = true
 
-  mattr_accessor :debug_output
-  @@debug_output = $stdout
+  def self.debug=(flag)
+    @@debug = flag
+    Fortenet::Request.default_options.delete(:debug_output) unless flag
+  end
+
+  def self.debug_output=(output)
+    return unless debug
+    Fortenet::Request.debug_output(output)
+  end
 
   mattr_accessor :proxy_port
   @@proxy_port = 80
@@ -24,3 +31,7 @@ end
 
 require 'fortenet/request'
 require 'fortenet/client'
+
+
+# default starting point
+Fortenet.debug_output = $stdout

--- a/lib/fortenet/request.rb
+++ b/lib/fortenet/request.rb
@@ -4,7 +4,6 @@ require 'json'
 module Fortenet
   class Request
     include HTTParty
-    debug_output Fortenet.debug_output if Fortenet.debug
     format :json
     headers 'Accept' => 'application/json'
 

--- a/lib/fortenet/version.rb
+++ b/lib/fortenet/version.rb
@@ -1,3 +1,3 @@
 module Fortenet
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
debug would always be on because it was set by a class method call on load before any rails initializers ran that would contain possible overrides, refactored to have intended effect